### PR TITLE
Make the mention a link to the exact comment. [legacy]

### DIFF
--- a/foreground/addExtensionHelp.js
+++ b/foreground/addExtensionHelp.js
@@ -12,6 +12,7 @@ themeUtil.onload(() => {
     Changes on the new version!:
     <ul>
         <li>Fixed a bug with the notifications. (There is a high chance that you have to <input class="btn btn-xs btn-danger" type="button" value="Reset"> all of your user data in order to fix this.)</li>
+        <li>The <input class="btn btn-xs btn-danger" type="button" style="background-color: #646464; border: none;" value="Mention"></input> button now creates a link to the exact comment it's a reply to.</li>
     </ul>
 </div>
 <h3 id="nyaa-getting-help">
@@ -91,7 +92,7 @@ themeUtil.onload(() => {
         <li>
             Adds a reply feature (in the comments), this feature implements the following.
             <ul>
-                <li>A  <input class="btn btn-xs btn-danger" type="button" style="background-color: #646464; border: none;" value="Mention"></input> button next to usernames, when clicked it appends the @username of said user.</li>
+                <li>A  <input class="btn btn-xs btn-danger" type="button" style="background-color: #646464; border: none;" value="Mention"></input> button next to usernames, when clicked it appends the @username of said user, as a link to the exact comment.</li>
                 <li>When a message contains your @username, that message becomes highlighted and the <mark>@username</mark> gets marked.</li>
             </ul>
         </li>

--- a/foreground/mentionUser.js
+++ b/foreground/mentionUser.js
@@ -25,7 +25,14 @@ nyaaUtility.storage.system.onload(() => {
         $(user).after(mentionButton);
 
         comment.querySelector("input").onclick = () => {
-            textArea.value += "@" + user?.innerText.trim() + " ";
+            // Get the current URL
+            let currentUrl = window.location.href;
+            // strip anchors from the url if there are any
+            currentUrl = currentUrl.split('#')[0];
+            // Create a link to the current page with the comment id appended
+            let link = currentUrl + '#' + comment.id;
+            // Make the mention a markdown link to the comment
+            textArea.value += `[@${user?.innerText.trim()}](${link}) `;
             window.scrollTo(0, document.body.scrollHeight);
         };
     });

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
         "storage",
         "notifications"
     ],
-    "version": "1.9",
+    "version": "1.9.1",
     "author": "Arjix",
     "description": "An extension that customizes nyaa.",
     "icons": {


### PR DESCRIPTION
As the title says, the mention button, instead of just a plaintext @, makes the mention a link to the exact comment it's a reply to.