### PR TITLE
Finish reply button behaviour [rewrite-v2]

### DIFF
--- a/src/Modules/commentReply.ts
+++ b/src/Modules/commentReply.ts
@@ -1,10 +1,14 @@
-import type { Module } from "./index"
+import type { Module } from "./index";
 import type { Config } from "../storage";
 
 export default class CommentReply implements Module {
-    id = "commentReplyBtn"
-    shouldRun: RegExp = /\/view\/\d+/
+    id = "commentReplyBtn";
+    shouldRun: RegExp = /\/view\/\d+/;
     injectWithConfig = true;
+
+    // global variable to store the reply name and comment id
+    replyTo: string | undefined = undefined;
+    commentId: string | undefined = undefined;
 
     injectCss = `
         .reply-bar {
@@ -55,7 +59,7 @@ export default class CommentReply implements Module {
 
     // prettier-ignore
     setupReplyBar(): HTMLDivElement | undefined {
-        const textarea = document.querySelector<HTMLTextAreaElement>("textarea#comment")
+        const textarea = document.querySelector<HTMLTextAreaElement>("textarea#comment");
         const submitBtn = document.querySelector<HTMLButtonElement>(`.comment-box input[type="submit"]`);
         const form = document.querySelector<HTMLFormElement>("form.comment-box");
         if (!textarea || !submitBtn || !form) return;
@@ -69,21 +73,22 @@ export default class CommentReply implements Module {
         Object.assign(replyBar, {
             className: "reply-bar hidden-reply-bar",
         });
+        
         //  onclick="${`let c = this.parentElement.parentElement.parentElement.dataset.comment; if (!c) return; window.location.hash = c`}"
         replyBar.innerHTML = `
             <p>
                 Replying to <strong><i class="reply-target"></i></strong>
             </p>
-            <span onclick="this.parentElement.classList.add('hidden-reply-bar'); this.parentElement.dataset.comment=undefined" class="glyphicon glyphicon-remove-circle"></span>
+            <span data-remove-mention onclick="this.parentElement.classList.add('hidden-reply-bar'); this.parentElement.dataset.comment=undefined;" class="glyphicon glyphicon-remove-circle"></span>
         `;
 
         return replyBar;
     }
 
     async inject(config?: Config) {
-        if (!config) return
-        const replyBar = this.setupReplyBar()
-        if (!replyBar) return
+        if (!config) return;
+        const replyBar = this.setupReplyBar();
+        if (!replyBar) return;
 
         if (import.meta.env.DEV)
             // prettier-ignore
@@ -107,7 +112,28 @@ export default class CommentReply implements Module {
                     replyBar.classList.remove("hidden-reply-bar");
                     replyBar.dataset.comment = comment.id;
                     window.location.hash = comment.id;
-                    document.querySelector<HTMLElement>(".reply-target")!.innerText = user.split("/").pop()! + "#" + comment.id;
+                    let mentionedUser = user.split("/").pop()
+                    document.querySelector<HTMLElement>(".reply-target")!.innerText = mentionedUser + "#" + comment.id;
+
+                    // Get current URL and remove any anchors if present
+                    let currentUrl = window.location.href;
+                    currentUrl = currentUrl.split("#")[0];
+
+                    // Get the current value of the CodeMirror and add the mention to it
+                    const cm = document.querySelector('.CodeMirror').CodeMirror;
+                    const currentValue = cm.getValue();
+
+                    const link = `[@${mentionedUser}](${currentUrl}#${comment.id})`;
+                    cm.setValue(`${link} ${currentValue}`);
+
+                    // If this.replyTo is already set, remove that mention from the CodeMirror
+                    if (this.replyTo) {
+                        this.removeMentionFromCodeMirror("replyBtn");
+                    }
+                    
+                    // Update the global variables
+                    this.replyTo = mentionedUser
+                    this.commentId = comment.id
                 },
             });
 
@@ -115,5 +141,28 @@ export default class CommentReply implements Module {
                 .querySelector("div.col-md-10.comment")
                 ?.insertAdjacentElement("afterend", button);
         });
+
+        // Add event listener to remove mention from CodeMirror
+        document.addEventListener("click", (event) => {
+            const target = event.target as HTMLElement;
+            if (target.dataset.removeMention !== undefined) {
+                this.removeMentionFromCodeMirror("removeBtn");
+            }
+        });
     }
+
+// Function to remove mention from CodeMirror
+// It's called when the user clicks on the remove mention icon, or when the user clicks on the reply button, and there's already a mention.
+removeMentionFromCodeMirror(caller?: string) {
+    const cm = document.querySelector('.CodeMirror').CodeMirror;
+    const currentValue = cm.getValue();
+    const mentionRegex = new RegExp(`\\[@${this.replyTo}+\\]\\(.+${this.commentId}\\) `, 'g');
+    cm.setValue(currentValue.replace(mentionRegex, ''));
+    
+    // if the caller is the remove button, reset the global variables
+    if (caller == "removeBtn") {
+        this.replyTo = undefined;
+        this.commentId = undefined;
+    }
+}
 }


### PR DESCRIPTION
Re: https://github.com/ArjixWasTaken/Nyaa-Utility/pull/20#issuecomment-2094220924

Finish the reply button.

Seems like this was already half implemented to do what I was doing in the other branches.
Now it adds the markdown mention to the comments, removes it when the X is pressed, or the user wants to reply to someone else instead. (it only deletes the one it has to, other mentions or markdown links are unaffected)

I'm not a frontend developer myself, I have barely any experience with JS/TypeScript/whatever else this uses, so it might be a bit janky.